### PR TITLE
Update Package Dependencies (BigSpans v23.3.0)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,7 +23,7 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_else = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = false
-csharp_new_line_before_open_brace = anonymous_types, control_blocks, events, indexers, local_functions, methods, object_collection_array_initalizers, properties, types
+csharp_new_line_before_open_brace = anonymous_types, control_blocks, events, indexers, local_functions, methods, properties, types
 csharp_new_line_between_query_expression_clauses = true
 csharp_preferred_modifier_order = public, private, protected, internal, new, abstract, virtual, sealed, override, static, readonly, extern, unsafe, volatile, async:suggestion
 csharp_preserve_single_line_blocks = true
@@ -651,8 +651,6 @@ dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
-file_header_template = # ReSharper properties
-
 resharper_alignment_tab_fill_style = use_spaces
 resharper_align_first_arg_by_paren = false
 resharper_align_linq_query = false

--- a/StirlingLabs.Utilities.Extensions/StirlingLabs.Utilities.Extensions.csproj
+++ b/StirlingLabs.Utilities.Extensions/StirlingLabs.Utilities.Extensions.csproj
@@ -23,7 +23,7 @@
         <PackageReference Include="StirlingLabs.LLVMSharp" Version="14.0.6.44479" />
         <PackageReference Include="StirlingLabs.LLVMSharp.Interop" Version="14.0.6.44479" />
         <PackageReference Include="StirlingLabs.libLLVM" Version="14.0.6.4" />
-        <PackageReference Include="StirlingLabs.BigSpans" Version="22.9.4" />
+        <PackageReference Include="StirlingLabs.BigSpans" Version="23.3.1" />
         <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)'=='net5.0' Or '$(TargetFramework)'=='net6.0'">

--- a/StirlingLabs.Utilities.Tests/StirlingLabs.Utilities.Tests.Net60.csproj
+++ b/StirlingLabs.Utilities.Tests/StirlingLabs.Utilities.Tests.Net60.csproj
@@ -54,8 +54,8 @@
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="StirlingLabs.BigSpans" Version="22.9.4" />
-        <PackageReference Include="StirlingLabs.BigSpans.NUnit" Version="22.9.4" />
+        <PackageReference Include="StirlingLabs.BigSpans" Version="23.3.1" />
+        <PackageReference Include="StirlingLabs.BigSpans.NUnit" Version="23.3.1" />
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="all" />
         <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all" />
         <PackageReference Include="NuGet.Versioning" Version="6.5.0" />

--- a/StirlingLabs.Utilities.Tests/StirlingLabs.Utilities.Tests.Net70.csproj
+++ b/StirlingLabs.Utilities.Tests/StirlingLabs.Utilities.Tests.Net70.csproj
@@ -54,8 +54,8 @@
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="StirlingLabs.BigSpans" Version="22.9.4" />
-        <PackageReference Include="StirlingLabs.BigSpans.NUnit" Version="22.9.4" />
+        <PackageReference Include="StirlingLabs.BigSpans" Version="23.3.1" />
+        <PackageReference Include="StirlingLabs.BigSpans.NUnit" Version="23.3.1" />
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="all" />
         <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all" />
         <PackageReference Include="NuGet.Versioning" Version="6.5.0" />

--- a/StirlingLabs.Utilities.Tests/StirlingLabs.Utilities.Tests.Netstandard20.csproj
+++ b/StirlingLabs.Utilities.Tests/StirlingLabs.Utilities.Tests.Netstandard20.csproj
@@ -52,8 +52,8 @@
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="StirlingLabs.BigSpans" Version="22.9.4" />
-        <PackageReference Include="StirlingLabs.BigSpans.NUnit" Version="22.9.4" />
+        <PackageReference Include="StirlingLabs.BigSpans" Version="23.3.1" />
+        <PackageReference Include="StirlingLabs.BigSpans.NUnit" Version="23.3.1" />
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="all" />
         <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/StirlingLabs.Utilities.Tests/StirlingLabs.Utilities.Tests.Netstandard21.csproj
+++ b/StirlingLabs.Utilities.Tests/StirlingLabs.Utilities.Tests.Netstandard21.csproj
@@ -52,8 +52,8 @@
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="StirlingLabs.BigSpans" Version="22.9.4" />
-        <PackageReference Include="StirlingLabs.BigSpans.NUnit" Version="22.9.4" />
+        <PackageReference Include="StirlingLabs.BigSpans" Version="23.3.1" />
+        <PackageReference Include="StirlingLabs.BigSpans.NUnit" Version="23.3.1" />
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="all" />
         <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/StirlingLabs.Utilities/StirlingLabs.Utilities.csproj
+++ b/StirlingLabs.Utilities/StirlingLabs.Utilities.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="InlineIL.Fody" Version="1.7.4" PrivateAssets="all" />
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="all" />
         <PackageReference Include="MedallionPriorityQueue.Inline" Version="1.1.0" PrivateAssets="all" />
-        <PackageReference Include="StirlingLabs.BigSpans" Version="22.9.4" />
+        <PackageReference Include="StirlingLabs.BigSpans" Version="23.3.1" />
         <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)'=='net5.0' Or '$(TargetFramework)'=='net6.0' Or '$(TargetFramework)'=='net7.0'">

--- a/StirlingLabs.Utilities/SystemFingerprint.cs
+++ b/StirlingLabs.Utilities/SystemFingerprint.cs
@@ -59,7 +59,7 @@ public static class SystemFingerprint
                 return lpa.Equals(rpa)
                     ? 0
                     : new ReadOnlyBigSpan<byte>(lpa.GetAddressBytes())
-                        .SequenceCompare(rpa.GetAddressBytes());
+                        .SequenceCompareTo(rpa.GetAddressBytes());
             });
 
         Span<byte> buffer = stackalloc byte[8];


### PR DESCRIPTION
also fixes some unrelated stuff in .editorconfig
<!-- output start -->
<details><summary>Code Coverage</summary>

&nbsp;
</details>
<!-- output end -->