### PR TITLE
Pull in UCLDR automatically for dependents on StirlingLabs.Utilities.Text

### DIFF
--- a/StirlingLabs.Utilities.Text/StirlingLabs.Utilities.Text.props
+++ b/StirlingLabs.Utilities.Text/StirlingLabs.Utilities.Text.props
@@ -2,7 +2,7 @@
 
 <Project>
     <PropertyGroup>
-        <StirlingLabsUtilitiesTextVersion Condition="'$(StirlingLabsUtilitiesTextVersion)'==''">*</StirlingLabsUtilitiesTextVersion>
+        <StirlingLabsIcu4xVersion Condition="'$(StirlingLabsIcu4xVersion)'==''">*</StirlingLabsIcu4xVersion>
         <StirlingLabsUtilitiesTextRuntimeId Condition="'$(StirlingLabsUtilitiesTextRuntimeId)'==''">$(RuntimeIdentifier)</StirlingLabsUtilitiesTextRuntimeId>
         <StirlingLabsUtilitiesTextRuntimeId Condition="'$(StirlingLabsUtilitiesTextRuntimeId)'==''">$(DefaultAppHostRuntimeIdentifier)</StirlingLabsUtilitiesTextRuntimeId>
         <StirlingLabsUtilitiesTextRuntimeId Condition="'$(StirlingLabsUtilitiesTextRuntimeId)'==''">$(NETCoreSdkPortableRuntimeIdentifier)</StirlingLabsUtilitiesTextRuntimeId>
@@ -27,7 +27,7 @@
     </ItemGroup>
     <ItemGroup
         Condition="$(StirlingLabsUtilitiesTextSelectAllRuntimes) OR $(StirlingLabsUtilitiesTextRuntimeId.StartsWith('linux'))">
-        <PackageReference Include="StirlingLabs.icu4x.runtime.linux-x64" Version="$(StirlingLabsUtilitiesTextVersion)"/>
+        <PackageReference Include="StirlingLabs.icu4x.runtime.linux-x64" Version="$(StirlingLabsIcu4xVersion)"/>
     </ItemGroup>
 
     <ItemGroup
@@ -36,7 +36,7 @@
     </ItemGroup>
     <ItemGroup
         Condition="$(StirlingLabsUtilitiesTextSelectAllRuntimes) OR $(StirlingLabsUtilitiesTextRuntimeId.StartsWith('osx'))">
-        <PackageReference Include="StirlingLabs.icu4x.runtime.osx" Version="$(StirlingLabsUtilitiesTextVersion)"/>
+        <PackageReference Include="StirlingLabs.icu4x.runtime.osx" Version="$(StirlingLabsIcu4xVersion)"/>
     </ItemGroup>
 
     <ItemGroup
@@ -45,6 +45,13 @@
     </ItemGroup>
     <ItemGroup
         Condition="$(StirlingLabsUtilitiesTextSelectAllRuntimes) OR $(StirlingLabsUtilitiesTextRuntimeId.StartsWith('win'))">
-        <PackageReference Include="StirlingLabs.icu4x.runtime.win-x64" Version="$(StirlingLabsUtilitiesTextVersion)"/>
+        <PackageReference Include="StirlingLabs.icu4x.runtime.win-x64" Version="$(StirlingLabsIcu4xVersion)"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Remove="StirlingLabs.icu4x.ucldr"/>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="StirlingLabs.icu4x.ucldr" Version="$(StirlingLabsIcu4xVersion)"/>
     </ItemGroup>
 </Project>

--- a/StirlingLabs.Utilities.Text/StirlingLabs.Utilities.Text.targets
+++ b/StirlingLabs.Utilities.Text/StirlingLabs.Utilities.Text.targets
@@ -11,7 +11,7 @@
     <Target Name="StirlingLabsUtilitiesTextSelectRuntime"
             BeforeTargets="GetRestoreProjectStyleTask;_GetAllRestoreProjectPathItems;_LoadRestoreGraphEntryPoints;_GenerateRestoreProjectSpec;Restore;CoreBuild">
         <PropertyGroup>
-            <StirlingLabsUtilitiesTextVersion Condition="'$(StirlingLabsUtilitiesTextVersion)'==''">*</StirlingLabsUtilitiesTextVersion>
+            <StirlingLabsIcu4xVersion Condition="'$(StirlingLabsIcu4xVersion)'==''">*</StirlingLabsIcu4xVersion>
             <StirlingLabsUtilitiesTextSelectRuntimeId Condition="'$(StirlingLabsUtilitiesTextSelectRuntimeId)'==''">$(RuntimeIdentifier)</StirlingLabsUtilitiesTextSelectRuntimeId>
             <StirlingLabsUtilitiesTextSelectRuntimeId Condition="'$(StirlingLabsUtilitiesTextSelectRuntimeId)'==''">$(DefaultAppHostRuntimeIdentifier)</StirlingLabsUtilitiesTextSelectRuntimeId>
             <StirlingLabsUtilitiesTextSelectRuntimeId Condition="'$(StirlingLabsUtilitiesTextSelectRuntimeId)'==''">$(NETCoreSdkPortableRuntimeIdentifier)</StirlingLabsUtilitiesTextSelectRuntimeId>
@@ -28,7 +28,7 @@
         <CreateItem
             Condition="$(StirlingLabsUtilitiesTextSelectAllRuntimes) OR $(StirlingLabsUtilitiesTextSelectRuntimeId.StartsWith('linux'))"
             Include="StirlingLabs.icu4x.runtime.linux-x64"
-            AdditionalMetadata="Version=$(StirlingLabsUtilitiesTextVersion)">
+            AdditionalMetadata="Version=$(StirlingLabsIcu4xVersion)">
             <Output TaskParameter="Include" ItemName="PackageReference" />
         </CreateItem>
 
@@ -39,7 +39,8 @@
         </ItemGroup>
         <CreateItem
             Condition="$(StirlingLabsUtilitiesTextSelectAllRuntimes) OR $(StirlingLabsUtilitiesTextSelectRuntimeId.StartsWith('osx'))"
-            Include="StirlingLabs.icu4x.runtime.osx" AdditionalMetadata="Version=$(StirlingLabsUtilitiesTextVersion)">
+            Include="StirlingLabs.icu4x.runtime.osx"
+            AdditionalMetadata="Version=$(StirlingLabsIcu4xVersion)">
             <Output TaskParameter="Include" ItemName="PackageReference" />
         </CreateItem>
 
@@ -51,9 +52,18 @@
         <CreateItem
             Condition="$(StirlingLabsUtilitiesTextSelectAllRuntimes) OR $(StirlingLabsUtilitiesTextSelectRuntimeId.StartsWith('win'))"
             Include="StirlingLabs.icu4x.runtime.win-x64"
-            AdditionalMetadata="Version=$(StirlingLabsUtilitiesTextVersion)">
+            AdditionalMetadata="Version=$(StirlingLabsIcu4xVersion)">
             <Output TaskParameter="Include" ItemName="PackageReference" />
         </CreateItem>
-
+        
+        <!-- UCLDR -->
+        <ItemGroup>
+            <PackageReference Remove="StirlingLabs.icu4x.ucldr" />
+        </ItemGroup>
+        <CreateItem
+            Include="StirlingLabs.icu4x.ucldr"
+            AdditionalMetadata="Version=$(StirlingLabsIcu4xVersion)">
+            <Output TaskParameter="Include" ItemName="PackageReference" />
+        </CreateItem>
     </Target>
 </Project>


### PR DESCRIPTION
Adds UCLDR package dependency to props and targets.

Renames the ICU4X Runtime and UCLDR specific version variable.
<!-- output start -->
<details><summary>Code Coverage</summary>

&nbsp;
</details>
<!-- output end -->